### PR TITLE
Fixes RSAT query so test_all passes

### DIFF
--- a/cmonkey/rsat.py
+++ b/cmonkey/rsat.py
@@ -121,9 +121,13 @@ class RsatDatabase:
         """returns the specified organism name file contents"""
         logging.debug('RSAT - get_organism_names(%s)', organism)
         cache_file = "/".join([self.cache_dir, 'rsatnames_' + organism])
+        #Changed 02-19-15 due to missing organism_names file in h.pylori
+        #text = util.read_url_cached(
+        #    "/".join([self.base_url, RsatDatabase.DIR_PATH, organism,
+        #              RsatDatabase.ORGANISM_NAMES_PATH]), cache_file)
         text = util.read_url_cached(
             "/".join([self.base_url, RsatDatabase.DIR_PATH, organism,
-                      RsatDatabase.ORGANISM_NAMES_PATH]), cache_file)
+                      RsatDatabase.ORGANISM_PATH]), cache_file)
         organism_names_dfile = util.dfile_from_text(text, comment='--')
         return patches.patch_ncbi_taxonomy(organism_names_dfile.lines[0][0])
 

--- a/test/rsat_test.py
+++ b/test/rsat_test.py
@@ -10,7 +10,7 @@ import rsat
 import util
 
 
-RSAT_BASE_URL = 'http://teaching.rsat.eu/rsa-tools'
+RSAT_BASE_URL = 'http://pedagogix-tagc.univ-mrs.fr/rsat'
 
 
 class RsatDatabaseTest(unittest.TestCase):  # pylint: disable-msg=R0904

--- a/test/testutil.py
+++ b/test/testutil.py
@@ -8,7 +8,7 @@ import organism as org
 KEGG_FILE_PATH = 'config/KEGG_taxonomy'
 GO_FILE_PATH = 'config/proteome2taxid'
 CACHE_DIR = 'cache'
-RSAT_BASE_URL = 'http://teaching.rsat.eu/rsa-tools'
+RSAT_BASE_URL = 'http://pedagogix-tagc.univ-mrs.fr/rsat'
 
 def make_halo(search_distances, scan_distances, ratios=None):
     """returns the organism object to work on"""


### PR DESCRIPTION
Modified get_taxonomy_id to use organism.tab file instead of organism_names.tab.  This file was missing from the new RSAT database

Tested on both mac and linux