### PR TITLE
fixed bug that caused incorrect number of nodes to be reported

### DIFF
--- a/cmonkey/stringdb.py
+++ b/cmonkey/stringdb.py
@@ -96,7 +96,7 @@ def get_network_factory(organism_code, filename, weight, sep='\t',
                         gene_lut[node] = node
                         if node in thesaurus:
                             gene_lut[thesaurus[node]] = node
-                total_nodes += 1
+                    total_nodes += 1
 
             score = float(line[2])
             max_score = max(score, max_score)


### PR DESCRIPTION
Minor edit in stringdb.py to stop total_nodes from counting each gene more than once. (Previously even if every node gets excluded from the network, the output suggests that some have been included, which isn't helpful when trying to work out where things have gone wrong!)